### PR TITLE
do not call pollWifi after connection has been made

### DIFF
--- a/src/Connection.js
+++ b/src/Connection.js
@@ -94,7 +94,6 @@ class Connection extends Component {
       .then(response => response.json())
       .then(connection => {
         this.setState({...connection, selected: connection.current});
-        this.pollWifi();
       })
       .catch(() => {
         toast.error(`Could not connect to network ${selected}`, {


### PR DESCRIPTION
The UI displayed a false warning about not being able to connect to a network while setting wifi the credentials.